### PR TITLE
Use Promises instead of blocking ideology

### DIFF
--- a/src/html.js
+++ b/src/html.js
@@ -38,13 +38,11 @@ export default function generateHTML(tag, params, ...children) {
 			if(child.isHTMLGenerator) {
 				streamPromise = child(streamPromise);
 			} else if(child.then) { // Some Promise returning a isHTMLGenerator
-				streamPromise = streamPromise.then(stream => {
-					return child.then(elements => {
-						if(!elements.isHTMLGenerator) {
-							throw new Error("Expecting promise to return a HTML generator function");
-						}
-						return elements(Promise.resolve(stream));
-					});
+				streamPromise = Promise.all([streamPromise, child]).then(function([stream, elements]) {
+					if(!elements.isHTMLGenerator) {
+						throw new Error("Expecting promise to return a HTML generator function");
+					}
+					return elements(Promise.resolve(stream));
 				});
 			} else if(child.call) { // Some function returning a isHTMLGenerator
 				let elements = child();

--- a/src/html.js
+++ b/src/html.js
@@ -9,6 +9,19 @@ const VOID_ELEMENTS = {}; // poor man's set
 	VOID_ELEMENTS[tag] = true;
 });
 
+// This function is basically called by `createElement` (with the same
+// parameters). The indirection is a simple abstaction to
+// encapsulate the macro functionality and not to mess this function
+// up even more.
+// The return value is a function again which is used to
+// build up a promise chain (taking a promise and returning a
+// promise based upon the input promise).
+// Why don't we build up the promise chain directly? The reason
+// is that we don't have the possibility to put a promise object
+// into generateHTML's parameter list since the method is called
+// without any context by createElement (wich doesn't have any context
+// too). So the returned "middle" function is only used to pass in the
+// promise.
 export default function generateHTML(tag, params, ...children) {
 	let fn = streamPromise => {
 		streamPromise = streamPromise.then(stream => {

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -4,9 +4,13 @@ import { flatCompact } from "./util";
 const TAG_MACROS = {};
 
 export default function documentRenderer(doctype = "<!DOCTYPE html>") {
-	return (stream, element, params) => {
-		stream.writeln(doctype);
-		createElement(element, params)(stream);
+	return (stream, element, params, ...children) => {
+		let p = Promise.resolve(stream).
+			then(stream => {
+				stream.writeln(doctype);
+				return stream;
+			});
+		return createElement(element, params, ...children)(p);
 	};
 }
 

--- a/test/macros.js
+++ b/test/macros.js
@@ -1,5 +1,9 @@
 let { registerMacro, createElement: h } = require("../src/renderer");
 
+registerMacro("simple", ({ title }, ...children) => {
+	return h("div", { title }, children);
+});
+
 registerMacro("site-index", ({ title }) => {
 	return h("default-layout", { title },
 			h("h1", null, title),


### PR DESCRIPTION
The current implementation breaks if someone uses an asynchronous call in the `children` sub functions.

This will fix this problem by using Promises everywhere. It'll also allow the usage of Promises (returning createElement results) in `children` parameters.

See tests for details