### PR TITLE
removed macro registry in favor of CamelCase convention

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "complate-stream",
-	"version": "0.10.0",
+	"version": "0.11.0",
 	"description": "complate's core library for server-side rendering via JSX",
 	"author": "FND",
 	"license": "Apache-2.0",
@@ -23,11 +23,11 @@
 	},
 	"dependencies": {},
 	"devDependencies": {
-		"@std/esm": "^0.2.1",
-		"eslint": "^4.4.1",
+		"@std/esm": "^0.7.1",
+		"eslint": "^4.6.0",
 		"eslint-config-fnd": "^1.2.0",
 		"mocha": "^3.5.0",
-		"npm-run-all": "^4.0.2",
-		"release-util-fnd": "^1.0.4"
+		"npm-run-all": "^4.1.1",
+		"release-util-fnd": "^1.0.5"
 	}
 }

--- a/src/html.js
+++ b/src/html.js
@@ -171,7 +171,7 @@ function htmlEncode(str, attribute) {
 function abort(msg, value, tag) {
 	msg = `${msg}: \`${JSON.stringify(value)}\``;
 	if(tag) {
-		msg += ` - did you perhaps forget to register \`${tag}\` as a macro?`;
+		msg += ` - did you perhaps intend to use \`${tag}\` as a macro?`;
 	}
 	throw new Error(msg);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
-import documentRenderer, { registerMacro, createElement } from "./renderer";
+import documentRenderer, { createElement } from "./renderer";
 import generateHTML, { HTMLString } from "./html";
 
 export default documentRenderer;
-export { registerMacro, createElement, generateHTML, safe };
+export { createElement, generateHTML, safe };
 
 function safe(str) {
 	return new HTMLString(str);

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,8 +1,6 @@
 import generateHTML from "./html";
 import { flatCompact, noop } from "./util";
 
-const TAG_MACROS = {};
-
 export default function documentRenderer(doctype = "<!DOCTYPE html>") {
 	return (stream, tag, params, callback) => {
 		if(doctype) {
@@ -18,18 +16,11 @@ export default function documentRenderer(doctype = "<!DOCTYPE html>") {
 	};
 }
 
-export function registerMacro(tag, fn) { // TODO: rename?
-	if(TAG_MACROS[tag]) {
-		throw new Error(`invalid tag macro: <${tag}> already registered`);
-	}
-
-	TAG_MACROS[tag] = fn;
-}
-
-export function createElement(tag, params, ...children) {
-	let macro = TAG_MACROS[tag];
+// distinguishes regular tags from macros
+export function createElement(element, params, ...children) {
 	/* eslint-disable indent */
-	return macro ? macro(params, ...flatCompact(children)) :
-			generateHTML(tag, params, ...children);
+	return element.call ?
+			element(params, ...flatCompact(children)) :
+			generateHTML(element, params, ...children);
 	/* eslint-enable indent */
 }

--- a/test/macros.js
+++ b/test/macros.js
@@ -1,25 +1,13 @@
-import { registerMacro, createElement as h } from "../src/renderer";
+import { createElement as h } from "../src/renderer";
 
-registerMacro("site-index", ({ title }) => {
-	return h("default-layout", { title },
+export function SiteIndex({ title }) {
+	return h(DefaultLayout, { title },
 			h("h1", null, title),
 			h("p", null, "…"));
-});
+}
 
-registerMacro("default-layout", ({ title }, ...children) => {
-	return h("html", null,
-			h("head", null,
-					h("meta", { charset: "utf-8" }),
-					h("title", null, title)),
-			h("body", null, children));
-});
-
-registerMacro("fragment-layout", (_, ...children) => {
-	return h("div", null, children);
-});
-
-registerMacro("blocking-container", _ => {
-	return h("fragment-layout", null,
+export function BlockingContainer() {
+	return h(FragmentLayout, null,
 			h("p", null, "…"),
 			h("p", null, callback => {
 				let el = h("i", null,
@@ -32,10 +20,10 @@ registerMacro("blocking-container", _ => {
 				callback(el);
 			}),
 			h("p", null, "…"));
-});
+}
 
-registerMacro("nonblocking-container", _ => {
-	return h("fragment-layout", null,
+export function NonBlockingContainer() {
+	return h(FragmentLayout, null,
 			h("p", null, "…"),
 			h("p", null, callback => {
 				setTimeout(_ => {
@@ -44,15 +32,16 @@ registerMacro("nonblocking-container", _ => {
 				}, 10);
 			}),
 			h("p", null, "…"));
-});
+}
 
-registerMacro("dummy-container", params => {
-	params = Object.assign({}, params);
-	let [tag, children] = ["_tag", "_children"].map(prop => {
-		let value = params[prop];
-		delete params[prop];
-		return value;
-	});
+function DefaultLayout({ title }, ...children) {
+	return h("html", null,
+			h("head", null,
+					h("meta", { charset: "utf-8" }),
+					h("title", null, title)),
+			h("body", null, children));
+}
 
-	return h(tag, params, ...children);
-});
+function FragmentLayout(_, ...children) {
+	return h("div", null, children);
+}

--- a/test/test_renderer.js
+++ b/test/test_renderer.js
@@ -1,5 +1,5 @@
 /* global describe, it */
-import "./macros";
+import { SiteIndex, BlockingContainer, NonBlockingContainer } from "./macros";
 import WritableStream from "./stream";
 import renderer from "../src/renderer";
 import assert from "assert";
@@ -39,7 +39,7 @@ describe("renderer", _ => {
 		let stream = new WritableStream();
 		let render = renderer(null);
 
-		render(stream, "blocking-container", {});
+		render(stream, BlockingContainer, null);
 		assert.equal(stream.read(),
 				"<div><p>…</p><p><i>lorem<em>…</em>ipsum</i></p><p>…</p></div>");
 		done();
@@ -49,20 +49,20 @@ describe("renderer", _ => {
 		let stream = new WritableStream();
 		let render = renderer(null);
 
-		let fn = _ => render(stream, "nonblocking-container", null);
+		let fn = _ => render(stream, NonBlockingContainer, null);
 		assert.throws(fn, /invalid non-blocking operation/);
 		done();
 	});
 
-	it("should render unknown elements which are not registered as macros", done => {
+	it("should render unknown elements", done => {
 		renderFragment("custom-element", null, html => {
 			assert.equal(html, "<custom-element></custom-element>");
 			done();
 		});
 	});
 
-	it("should perform markup expansion for registered macros", done => {
-		renderFragment("site-index", { title: "hello world" }, html => {
+	it("should perform markup expansion for macros", done => {
+		renderFragment(SiteIndex, { title: "hello world" }, html => {
 			assert.equal(html, "<html>" +
 					'<head><meta charset="utf-8"><title>hello world</title></head>' +
 					"<body><h1>hello world</h1><p>…</p></body>" +


### PR DESCRIPTION
JSX special-cases CamelCase tags to generate object references instead
of strings:

    <foo-bar /> → createElement("foo-bar")
    <fooBar />  → createElement("fooBar")
    <FooBar />  → createElement(FooBar)

while this is aesthetically and architecturally questionable, it does
obviate the need for a macro registry (which constituted a shared global
namespace) as we can directly use object references instead of having to
resolve certain tag names to the registered object - which has
wide-ranging implications:

* we no longer need to worry about namespace conflicts or conventions
* macros must be imported explicitly and thus can be traced to their
  respective origin (previously this was difficult, confusing and
  brittle)
* we can now use regular JavaScript tooling (e.g. for linting, as
  evidenced by the detection of the obsolete "dummy-container" macro)