### PR TITLE
turned renderer into a class

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "complate-stream",
-	"version": "0.12.4",
+	"version": "0.13.0",
 	"description": "complate's core library for server-side rendering via JSX",
 	"author": "FND",
 	"license": "Apache-2.0",
@@ -23,11 +23,11 @@
 	},
 	"dependencies": {},
 	"devDependencies": {
-		"@std/esm": "^0.9.2",
-		"eslint": "^4.6.1",
+		"@std/esm": "^0.11.2",
+		"eslint": "^4.8.0",
 		"eslint-config-fnd": "^1.2.0",
-		"mocha": "^3.5.3",
+		"mocha": "^4.0.0",
 		"npm-run-all": "^4.1.1",
-		"release-util-fnd": "^1.0.5"
+		"release-util-fnd": "^1.0.6"
 	}
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
-import renderer, { createElement } from "./renderer";
+import Renderer, { createElement } from "./renderer";
 import generateHTML, { HTMLString } from "./html";
 
-export default renderer;
+export default Renderer;
 export { createElement, generateHTML, safe };
 
 function safe(str) {

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,24 +1,34 @@
 import generateHTML from "./html";
 import { flatCompact, noop } from "./util";
 
-// generates a pair of functions:
-// `renderView` serves as the API for the host environment
-// `registerView` allows `render` to reference registered macros by their name
-export default function renderer(doctype = "<!DOCTYPE html>") {
-	let macros = {};
+// distinguishes macros from regular tags
+export function createElement(element, params, ...children) {
+	/* eslint-disable indent */
+	return element.call ?
+			element(params, ...flatCompact(children)) :
+			generateHTML(element, params, ...children);
+	/* eslint-enable indent */
+}
 
-	let registerView = (macro, name = macro.name, replace) => {
+export default class Renderer {
+	constructor(doctype = "<!DOCTYPE html>") {
+		this._doctype = doctype;
+		this._macroRegistry = {};
+	}
+
+	registerView(macro, name = macro.name, replace) {
 		if(!name) {
 			throw new Error(`missing name for macro: \`${macro}\``);
 		}
 
+		let macros = this._macroRegistry;
 		if(macros[name] && !replace) {
 			throw new Error(`invalid macro name: \`${name}\` already registered`);
 		}
 		macros[name] = macro;
 
 		return name; // primarily for debugging
-	};
+	}
 
 	// `view` is either a macro function or a string identifying a registered macro
 	// `params` is a mutable key-value object which is passed to the respective macro
@@ -26,9 +36,9 @@ export default function renderer(doctype = "<!DOCTYPE html>") {
 	// `fragment` is a boolean determining whether to omit doctype and layout
 	// `callback` is an optional function invoked upon conclusion - if provided,
 	// this activates non-blocking rendering
-	let renderView = (view, params, stream, fragment, callback) => {
+	renderView(view, params, stream, { fragment } = {}, callback) {
 		if(!fragment) {
-			stream.writeln(doctype);
+			stream.writeln(this._doctype);
 		}
 
 		if(fragment) {
@@ -38,28 +48,17 @@ export default function renderer(doctype = "<!DOCTYPE html>") {
 			params._layout = false; // XXX: hacky? (e.g. might break due to immutability)
 		}
 
-		// resolve strings to corresponding macro
-		let macro = (view && view.substr) ? macros[view] : view;
+		// resolve string identifier to corresponding macro
+		let macro = (view && view.substr) ? this._macroRegistry[view] : view;
 		if(!macro) {
-			throw new Error(`unknown macro: \`${view}\``);
+			throw new Error(`unknown view macro: \`${view}\` is not registered`);
 		}
-		let element = createElement(macro, params);
 
+		let element = createElement(macro, params);
 		if(callback) { // non-blocking mode
 			element(stream, true, callback);
 		} else { // blocking mode
 			element(stream, false, noop);
 		}
 	};
-
-	return { renderView, registerView };
-}
-
-// distinguishes regular tags from macros
-export function createElement(element, params, ...children) {
-	/* eslint-disable indent */
-	return element.call ?
-			element(params, ...flatCompact(children)) :
-			generateHTML(element, params, ...children);
-	/* eslint-enable indent */
 }

--- a/test/test_api.js
+++ b/test/test_api.js
@@ -1,0 +1,16 @@
+/* global describe, it */
+import Renderer, { createElement, generateHTML, safe } from "..";
+import assert from "assert";
+
+// XXX: crude
+describe("API", _ => {
+	it("should export specified API", () => {
+		let renderer = new Renderer();
+		assert(renderer.registerView.call);
+		assert(renderer.renderView.call);
+
+		assert(createElement.call);
+		assert(generateHTML.call);
+		assert(safe.call);
+	});
+});

--- a/test/test_renderer.js
+++ b/test/test_renderer.js
@@ -1,84 +1,90 @@
 /* global describe, it */
 import { SiteIndex, BlockingContainer, NonBlockingContainer } from "./macros";
 import WritableStream from "./stream";
-import renderer, { createElement } from "../src/renderer";
+import Renderer, { createElement } from "../src/renderer";
 import assert from "assert";
 
 describe("renderer", _ => {
 	it("should generate a render function for streaming HTML documents", done => {
-		let { renderView, stream } = setup(); // renderer defaults to HTML5
+		let { renderer, stream } = setup(); // renderer defaults to HTML5
 
-		renderView(HTMLRoot, null, stream, false, _ => {
+		renderer.renderView(HTMLRoot, null, stream, { fragment: false }, _ => {
 			assert.equal(stream.read(), "<!DOCTYPE html>\n<html></html>");
 			done();
 		});
 	});
 
 	it("should support custom doctypes", done => {
-		let { renderView, stream } = setup("<!DOCTYPE … XHTML …>");
+		let { renderer, stream } = setup("<!DOCTYPE … XHTML …>");
 
-		renderView(HTMLRoot, null, stream, false, _ => {
+		renderer.renderView(HTMLRoot, null, stream, { fragment: false }, _ => {
 			assert.equal(stream.read(), "<!DOCTYPE … XHTML …>\n<html></html>");
 			done();
 		});
 	});
 
 	it("should omit doctype for HTML fragments", done => {
-		let { renderView, stream } = setup();
+		let { renderer, stream } = setup();
 
-		renderView(HTMLRoot, null, stream, true, _ => {
+		renderer.renderView(HTMLRoot, null, stream, { fragment: true }, _ => {
 			assert.equal(stream.read(), "<html></html>");
 			done();
 		});
 	});
 
 	it("should support blocking mode", done => {
-		let { renderView, stream } = setup();
+		let { renderer, stream } = setup();
 
-		renderView(BlockingContainer, null, stream, true);
+		renderer.renderView(BlockingContainer, null, stream, { fragment: true });
 		assert.equal(stream.read(),
 				"<div><p>…</p><p><i>lorem<em>…</em>ipsum</i></p><p>…</p></div>");
 		done();
 	});
 
 	it("should detect non-blocking child elements in blocking mode", done => {
-		let { renderView, stream } = setup();
+		let { renderer, stream } = setup();
 
-		let fn = _ => renderView(NonBlockingContainer, null, stream);
+		let fn = _ => renderer.renderView(NonBlockingContainer, null, stream);
 		assert.throws(fn, /invalid non-blocking operation/);
 		done();
 	});
 
 	it("should perform markup expansion for macros", done => {
-		let { renderView, stream } = setup();
+		let { renderer, stream } = setup();
 
-		renderView(SiteIndex, { title: "hello world" }, stream, true, _ => {
+		/* eslint-disable indent */
+		renderer.renderView(SiteIndex, { title: "hello world" }, stream,
+				{ fragment: true }, _ => {
 			assert.equal(stream.read(), "<html>" +
 					'<head><meta charset="utf-8"><title>hello world</title></head>' +
 					"<body><h1>hello world</h1><p>…</p></body>" +
 					"</html>");
 			done();
 		});
+		/* eslint-enable indent */
 	});
 
 	it("should resolve registered macros", done => {
-		let { renderView, registerView, stream } = setup();
+		let { renderer, stream } = setup();
 
-		registerView(SiteIndex);
-		renderView("SiteIndex", { title: "hello world" }, stream, true, _ => {
+		renderer.registerView(SiteIndex);
+		/* eslint-disable indent */
+		renderer.renderView("SiteIndex", { title: "hello world" }, stream,
+				{ fragment: true }, _ => {
 			assert.equal(stream.read(), "<html>" +
 					'<head><meta charset="utf-8"><title>hello world</title></head>' +
 					"<body><h1>hello world</h1><p>…</p></body>" +
 					"</html>");
 			done();
 		});
+		/* eslint-enable indent */
 	});
 
 	it("should balk at unregistered macros", done => {
-		let { renderView, stream } = setup();
+		let { renderer, stream } = setup();
 
-		let fn = _ => renderView("foo", null, stream);
-		assert.throws(fn, /unknown macro/);
+		let fn = _ => renderer.renderView("foo", null, stream);
+		assert.throws(fn, /unknown view macro/);
 		done();
 	});
 });
@@ -88,7 +94,8 @@ function HTMLRoot() {
 }
 
 function setup(doctype) {
-	let stream = new WritableStream();
-	let { renderView, registerView } = renderer(doctype);
-	return { renderView, registerView, stream };
+	return {
+		renderer: new Renderer(doctype),
+		stream: new WritableStream()
+	};
 }


### PR DESCRIPTION
> this proved easier to understand, also because it makes the macro
> registry's scope more explicit
>
> also tweaked `#renderView`'s signature to avoid non-descriptive boolean
>
> before:
>
> ```javascript
> import renderer from "complate-stream";
> …
> let { renderView, registerView } = renderer(doctype);
> …
> registerView(…);
> renderView(view, params, stream, fragment, callback);
> ```
>
> after:
>
> ```javascript
> import Renderer from "complate-stream";
> …
> let renderer = new Renderer(doctype);
> …
> renderer.registerView(…);
> renderer.renderView(view, params, stream, { fragment }, callback);
> ```
>
> in the process, updated dependencies

6fc333a7370431e810b7200b2e949c4135aac84a
