### PR TITLE
Rendering non-blocking elements does not work

### DIFF
--- a/test/test_renderer.js
+++ b/test/test_renderer.js
@@ -42,6 +42,18 @@ describe("renderer", _ => {
 		done();
 	});
 
+	it("should support non-blocking mode", done => {
+		let { renderer, stream } = setup();
+
+		/* eslint-disable indent */
+		renderer.renderView(NonBlockingContainer, null, stream, { fragment: true }, _ => {
+			assert.equal(stream.read(),
+				"<div><p>…</p><p><i>lorem ipsum</i></p><p>…</p></div>");
+			done();
+		});
+		/* eslint-enable indent */
+	});
+
 	it("should detect non-blocking child elements in blocking mode", done => {
 		let { renderer, stream } = setup();
 


### PR DESCRIPTION
Note: This is a bug report with a test case attached.

We don't currently seem to have a test case that ensures that basic rendering
of async elements (in async mode) works correctly,
and the attached test fails on master, and not just since cc106c1a
but at least back at v0.12.0.
(Earlier versions had too different API for me to test easily.)

I may be misunderstanding the macro, but I expect it to render

         <div><p>…</p><p><i>lorem ipsum</i></p><p>…</p></div>

when instead it renders (note the different nesting):

         <div><p>…</p><p><p>…</p><i>lorem ipsum</i></p></div>

Note the incorrect nesting: I believe this is due to sibling elements
being rendered before a child *with asynchronous children*
has had a chance to finish rendering.