### PR TITLE
Add optional typescript type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 		"lint": "eslint --cache *.js src ./test/*.js ./test/nashorn/*.js && echo ✓"
 	},
 	"main": "src/index.js",
+	"types": "src/index.d.ts",
 	"@std/esm": {
 		"esm": "all"
 	},

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -20,8 +20,8 @@ declare type elementGenerator = (
 ) => void;
 
 // A macro
-interface StatelessFunctionalComponent<P> {
-	(props: P): elementGenerator;
+interface StatelessFunctionalComponent<T> {
+	(props: T): elementGenerator;
 }
 
 // ** Exports

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,48 +1,48 @@
 declare type elementGenerator = (
-  stream: Renderer.Stream,
-  nonBlocking: boolean,
-  callback: () => void
+	stream: Renderer.Stream,
+	nonBlocking: boolean,
+	callback: () => void
 ) => void;
 
 interface StatelessFunctionalComponent<P> {
-  (props: P): elementGenerator;
+	(props: P): elementGenerator;
 }
 
 declare function createElement<T>(
-  element: string | StatelessFunctionalComponent<T>,
-  params: T,
-  ...children
+	element: string | StatelessFunctionalComponent<T>,
+	params: T,
+	...children
 ): elementGenerator;
 
 declare function safe(str: string): Renderer.HTMLString;
 
 declare class Renderer {
-  constructor(doctype?: string);
+	constructor(doctype?: string);
 
-  renderView(
-    view: elementGenerator | string,
-    params: Object,
-    stream: Renderer.Stream,
-    { fragment: boolean }?,
-    callback?: () => void
-  ): void;
+	renderView(
+		view: elementGenerator | string,
+		params: Object,
+		stream: Renderer.Stream,
+		{ fragment: boolean }?,
+		callback?: () => void
+	): void;
 
-  registerView(
-    macro: () => elementGenerator,
-    name?: string,
-    replace?: boolean
-  ): string;
+	registerView(
+		macro: () => elementGenerator,
+		name?: string,
+		replace?: boolean
+	): string;
 }
 
 declare namespace Renderer {
-  export interface Stream {
-    write(msg: string): void;
-    writeln(msg: string): void;
-    flush(): void;
-  }
-  export class HTMLString {
+	export interface Stream {
+		write(msg: string): void;
+		writeln(msg: string): void;
+		flush(): void;
+	}
+	export class HTMLString {
 
-  }
+	}
 }
 
 export default Renderer;
@@ -51,8 +51,8 @@ export { createElement, safe };
 
 // Global definitions
 declare global {
-  namespace JSX {
-    // This is needed for attribute type checking in custom components
-    interface Element extends StatelessFunctionalComponent<any> { }
-  }
+	namespace JSX {
+		// This is needed for attribute type checking in custom components
+		interface Element extends StatelessFunctionalComponent<any> { }
+	}
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,58 @@
+declare type elementGenerator = (
+  stream: Renderer.Stream,
+  nonBlocking: boolean,
+  callback: () => void
+) => void;
+
+interface StatelessFunctionalComponent<P> {
+  (props: P): elementGenerator;
+}
+
+declare function createElement<T>(
+  element: string | StatelessFunctionalComponent<T>,
+  params: T,
+  ...children
+): elementGenerator;
+
+declare function safe(str: string): Renderer.HTMLString;
+
+declare class Renderer {
+  constructor(doctype?: string);
+
+  renderView(
+    view: elementGenerator | string,
+    params: Object,
+    stream: Renderer.Stream,
+    { fragment: boolean }?,
+    callback?: () => void
+  ): void;
+
+  registerView(
+    macro: () => elementGenerator,
+    name?: string,
+    replace?: boolean
+  ): string;
+}
+
+declare namespace Renderer {
+  export interface Stream {
+    write(msg: string): void;
+    writeln(msg: string): void;
+    flush(): void;
+  }
+  export class HTMLString {
+
+  }
+}
+
+export default Renderer;
+
+export { createElement, safe };
+
+// Global definitions
+declare global {
+  namespace JSX {
+    // This is needed for attribute type checking in custom components
+    interface Element extends StatelessFunctionalComponent<any> { }
+  }
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -26,6 +26,8 @@ interface StatelessFunctionalComponent<T> {
 
 // ** Exports
 
+declare const Fragment;
+
 declare function createElement<T>(
 	element: string | StatelessFunctionalComponent<T>,
 	params: T,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,15 +1,30 @@
 export default Renderer;
-export { createElement, safe };
+export { createElement, generateHTML, safe, htmlEncode };
 
+// ** TSX configuration
+
+declare global {
+	namespace JSX {
+		// This is needed for attribute type checking in custom components
+		interface Element extends StatelessFunctionalComponent<any> { }
+	}
+}
+
+// ** Types and interfaces
+
+// Return value of createElement
 declare type elementGenerator = (
 	stream: Renderer.Stream,
 	nonBlocking: boolean,
 	callback: () => void
 ) => void;
 
+// A macro
 interface StatelessFunctionalComponent<P> {
 	(props: P): elementGenerator;
 }
+
+// ** Exports
 
 declare function createElement<T>(
 	element: string | StatelessFunctionalComponent<T>,
@@ -17,7 +32,15 @@ declare function createElement<T>(
 	...children
 ): elementGenerator;
 
+declare function generateHTML(
+	tag: string,
+	params,
+	...children
+): elementGenerator;
+
 declare function safe(str: string): Renderer.HTMLString;
+
+declare function htmlEncode(str: string, attribute: boolean): string;
 
 declare class Renderer {
 	constructor(doctype?: string);
@@ -45,13 +68,5 @@ declare namespace Renderer {
 	}
 	export class HTMLString {
 
-	}
-}
-
-// Global definitions
-declare global {
-	namespace JSX {
-		// This is needed for attribute type checking in custom components
-		interface Element extends StatelessFunctionalComponent<any> { }
 	}
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,3 +1,6 @@
+export default Renderer;
+export { createElement, safe };
+
 declare type elementGenerator = (
 	stream: Renderer.Stream,
 	nonBlocking: boolean,
@@ -44,10 +47,6 @@ declare namespace Renderer {
 
 	}
 }
-
-export default Renderer;
-
-export { createElement, safe };
 
 // Global definitions
 declare global {

--- a/test/test_html.js
+++ b/test/test_html.js
@@ -30,7 +30,7 @@ describe("HTML rendering", _ => {
 	});
 });
 
-describe("HTML elements", _ => {
+describe("HTML elements", function() {
 	it("should support nested elements", done => {
 		let el = h("foo", null,
 				h("bar", null,
@@ -166,6 +166,20 @@ describe("HTML elements", _ => {
 		let fn = _ => el(stream, { nonBlocking: false }, noop);
 		assert.throws(fn, /invalid non-blocking operation/);
 		done();
+	});
+
+	it("should support large numbers of child elements", function(done) {
+		this.timeout(3000);
+
+		let range = Array.apply(null, Array(10000));
+		let el = h("ul", null, range.map((_, i) => {
+			return h("li", null, i);
+		}));
+
+		render(el, html => {
+			assert(html.includes("<li>9999</li></ul>"));
+			done();
+		});
 	});
 });
 


### PR DESCRIPTION
This allows typescript users to:

* Use typing in TSX :)
* `import ... from "complate-stream"` (since typescript doesn't support npm `main` property)

I didn't add tests for typescript since I didn't want to add typescript as developmentDependency. But maybe we should do something like that (later?).