### PR TITLE
Improve encode performance

### DIFF
--- a/src/html.js
+++ b/src/html.js
@@ -11,6 +11,14 @@ let VOID_ELEMENTS = {}; // poor man's `Set`
 	VOID_ELEMENTS[tag] = true;
 });
 
+let HTML_ENTITIES = {
+	"&": "&amp;",
+	"<": "&lt;",
+	">": "&gt;",
+	"\"": "&quot;",
+	"'": "&#x27;"
+};
+
 // generates an "element generator" function which serves as a placeholder and,
 // when invoked, writes the respective HTML to an output stream
 //
@@ -80,35 +88,27 @@ export function HTMLString(str) {
 	this.value = str;
 }
 
-const HTML_ENCODE_REPLACE = {
-	"&": "&amp;",
-	"<": "&lt;",
-	">": "&gt;",
-	"\"": "&quot;",
-	"'": "&#x27;"
-};
-
-// adapted from html-entities <https://github.com/mdevils/html-entities> (MIT LICENSE)
+// adapted from html-entities <https://github.com/mdevils/html-entities> (MIT license)
 export function htmlEncode(str, attribute) {
-	const rx = attribute ? /[&<>'"]/g : /[&<>]/g;
-	let res;
-	let match = rx.exec(str);
-	if(match) {
-		res = "";
-		let lastIndex = 0;
-		do {
-			if(lastIndex !== match.index) {
-				res += str.substring(lastIndex, match.index);
-			}
-			res += HTML_ENCODE_REPLACE[match[0]];
-			lastIndex = rx.lastIndex;
-		} while((match = rx.exec(str)));
+	let pattern = attribute ? /[&<>'"]/g : /[&<>]/g;
+	let match = pattern.exec(str);
+	if(!match) {
+		return str;
+	}
 
-		if(lastIndex !== str.length) {
-			res += str.substring(lastIndex);
+	let res = "";
+	let last = 0;
+	do {
+		let { index } = match;
+		if(last !== index) {
+			res += str.substring(last, index);
 		}
-	} else {
-		res = str;
+		res += HTML_ENTITIES[match[0]];
+		last = pattern.lastIndex;
+	} while((match = pattern.exec(str)));
+
+	if(last !== str.length) {
+		res += str.substring(last);
 	}
 	return res;
 }

--- a/src/html.js
+++ b/src/html.js
@@ -193,7 +193,7 @@ function generateAttributes(params, { tag, log, _idRegistry }) {
 		// regular attributes
 		default:
 			// cf. https://html.spec.whatwg.org/multipage/syntax.html#attributes-2
-			if(/ |"|'|>|'|\/|=/.test(name)) {
+			if(/[ "'>/=]/.test(name)) {
 				reportAttribError(`invalid HTML attribute name: ${repr(name)}`, tag, log);
 				break;
 			}

--- a/src/html.js
+++ b/src/html.js
@@ -80,14 +80,24 @@ export function HTMLString(str) {
 	this.value = str;
 }
 
-// adapted from TiddlyWiki <http://tiddlywiki.com> and Python 3's `html` module
+const HTML_ENCODE_REPLACE = {
+	"&": "&amp;",
+	"<": "&lt;",
+	">": "&gt;",
+	"\"": "&quot;",
+	"'": "&#x27;"
+};
+
 export function htmlEncode(str, attribute) {
-	let res = str.replace(/&/g, "&amp;").
-		replace(/</g, "&lt;").
-		replace(/>/g, "&gt;");
-	if(attribute) {
-		res = res.replace(/"/g, "&quot;").
-			replace(/'/g, "&#x27;");
+	const rx = attribute ? /[&<>'"]/g : /[&<>]/g;
+	let res;
+	// fast path for strings which don't need to be encoded
+	if(rx.test(str)) {
+		// reset index because test don't reset index (see https://mzl.la/3FVasRL)
+		rx.lastIndex = 0;
+		res = str.replace(rx, c => HTML_ENCODE_REPLACE[c]);
+	} else {
+		res = str;
 	}
 	return res;
 }

--- a/src/html.js
+++ b/src/html.js
@@ -88,14 +88,25 @@ const HTML_ENCODE_REPLACE = {
 	"'": "&#x27;"
 };
 
+// adapted from html-entities <https://github.com/mdevils/html-entities> (MIT LICENSE)
 export function htmlEncode(str, attribute) {
 	const rx = attribute ? /[&<>'"]/g : /[&<>]/g;
 	let res;
-	// fast path for strings which don't need to be encoded
-	if(rx.test(str)) {
-		// reset index because test don't reset index (see https://mzl.la/3FVasRL)
-		rx.lastIndex = 0;
-		res = str.replace(rx, c => HTML_ENCODE_REPLACE[c]);
+	let match = rx.exec(str);
+	if(match) {
+		res = "";
+		let lastIndex = 0;
+		do {
+			if(lastIndex !== match.index) {
+				res += str.substring(lastIndex, match.index);
+			}
+			res += HTML_ENCODE_REPLACE[match[0]];
+			lastIndex = rx.lastIndex;
+		} while((match = rx.exec(str)));
+
+		if(lastIndex !== str.length) {
+			res += str.substring(lastIndex);
+		}
 	} else {
 		res = str;
 	}


### PR DESCRIPTION
Hi. I have looked at issue #1 and find out that the current htmlEncode can be improved in performance. First i have tried to include html-entities, which will work but i was not brave enogh to include it, because it bundles a lot of stuff into the views bundle. Also htmlEncode is a public API of the library and i don't wanted to change it's produced encoding, because it might break user tests. So i ended up by creating a "own" implementation again, to speed things up.

### Micro-Benchmarks
The speed improvement highly depends on the input and the underlying javascript engine. I have prepared some micro-benchmarks for you, that shows the new version should be faster. Just click to run it, these benchmarks will only run the htmlEncode function with some input.

- [encode attribute, no escape](https://jsben.ch/KTc48) 
- [encode attribute, with escapes](https://jsben.ch/FY2dX)
- [encode content, no escape](https://jsben.ch/OegRF)
- [encode content, with escapes](https://jsben.ch/WTirT)

### Complate-cpp Benchmarks
I have also run complate-cpp rendering benchmarks with the current and the optimized implementation. I'm using a Intel i7-12700KF which runs an Ubuntu 20.04 on WSL2. All results are mean values of all iterations, i have taken best of five runs each, rounded to one decimal.

| Test                         | Current        | Optimized    |
| -------------------- | ------------: | ------------: |
| QuickJS, no todos    |         92.7 us |        60.0 us |
| QuickJS, 10 todos    |          1.2 ms |      771.1 us |
| QuickJS, 100 todos  |        11.5 ms |         7.5 ms |
| V8, no todos            |        10.7 us |          9.1 us |
| V8, 10 todos            |      149.4 us |      123.0 us |
| V8, 100 todos          |       1.44 ms |       1.26 ms |

To run the complate-cpp benchmarks by yourself on Linux, assuming you have the dependencies installed on your system.
```shell
mkdir build
cd build
cmake -DBUILD_TESTS=on ..
make
test/lib/complate-tests QuickJsRendererBenchmark
test/lib/complate-tests V8RendererBenchmark
```